### PR TITLE
added hue.discover (uses UDP broadcast to find bridge)

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,0 +1,17 @@
+var hue = require('./lib/hue');
+
+hue.discover(function (error, host) {
+  if (error) {
+    console.error(error);
+    return;
+  }
+
+  console.log("Discovered HUE at %s", host);
+  hue.load(host, "APPLICATION_KEY"); // need to register this first (not currently supported)
+
+  hue.lights(function(lights){
+      for(i in lights)
+          if(lights.hasOwnProperty(i))
+              hue.change(lights[i].set({"on": true, "rgb":[Math.random() * 256 >>> 0, Math.random() * 256 >>> 0, Math.random() * 256 >>> 0]}));
+  });
+});

--- a/lib/hue.js
+++ b/lib/hue.js
@@ -8,6 +8,60 @@ var crypto = require('crypto'),
 
 var authenticated = false;	
 
+exports.discover = function(timeout, callback) {
+
+  if (typeof(callback) == "undefined") {
+    callback = timeout;
+    timeout = 5000;
+  }
+
+  var os = require('os');
+  var dgram = require("dgram");
+
+  /* get a list of our local IPv4 addresses */
+
+  var interfaces = os.networkInterfaces();
+  var addresses = [];
+  for (var dev in interfaces) {
+    for (var i = 0; i < interfaces[dev].length; i++) {
+      if (interfaces[dev][i].family != 'IPv4') continue;
+      if (interfaces[dev][i].internal) continue;
+      addresses.push(interfaces[dev][i].address);
+    }
+  }
+
+  /* this code adapted from https://github.com/Burgestrand/ruhue/blob/master/lib/ruhue.rb#L23 */
+
+  var socket = dgram.createSocket("udp4");
+  socket.bind(function () {;
+    console.log("socket is bound, adding membership");
+    socket.setBroadcast(true);
+    socket.setMulticastTTL(128);
+    addresses.forEach(function (address) { socket.addMembership("239.255.255.250", address); });
+    var payload = new Buffer([
+        "M-SEARCH * HTTP/1.1",
+        "HOST: 239.255.255.250:1900",
+        "MAN: ssdp:discover",
+        "MX: 10",
+        "ST: ssdp:all"
+    ].join("\n"));
+    socket.on("error", console.error);
+    var timer = null;
+    socket.on("message", function (msg, rinfo) {
+      console.log(msg.toString('utf8'));
+      if (msg.toString('utf8').match(/IpBridge/)) { // check to see if it's a HUE responding
+        socket.close();
+        if (timer) clearTimeout(timer);
+        callback(null, rinfo.address);
+      }
+    });
+    socket.send(payload, 0, payload.length, 1900, "239.255.255.250", function () {
+      timer = setTimeout(function () { socket.close(); callback("discovery timeout expired"); }, timeout);
+    });
+  });
+
+}
+
 exports.load = function(host, key, callback) {
 	if(!callback) callback = function() {};
 


### PR DESCRIPTION
This is ported from ruhue, a Ruby HUE library I tinkered with a few months ago (I'm happy to be able to switch back to node).  At the moment I don't need the registration code, but that's pretty simple if you want to add it yourself:

https://github.com/Burgestrand/ruhue/blob/master/lib/ruhue/client.rb#L34

Also added example.js, based on your example in the README, but using discover to get the host and totally random colors to make the result more obvious.
